### PR TITLE
Node.JS installattion instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 bitmark.json
 audit.json
+rpcAuth.js

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ typings/
 
 bitmark.json
 audit.json
-rpcAuth.js

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ rpcpassword=You_Will_Get_Robbed_If_You_Use_This
 
 Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 
+
+If not already done, install Node.JS
+        For Debian / Ubuntu
+   $ sudo apt-get install npm
+   $ sudo apt-get install nodejs-legacy
+
 Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
+   ~/bitmark-audit $ npm install
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -58,3 +58,8 @@ Two tools are included in this repository: **monitor** and **audit**.
 ### Notes
 
 Monitoring began on 2017/07/07 at block height 286441.  `bitmark.json.bootstrap` is a log file created up to height 287571.  I (sneurlax) will work on uploading a canonical version of `bitmark.json` somewhere accessible "soon."
+
+To ignore your username/password changes to `rpcAuth.js`, use the following command (instead of adding it to `.gitignore`:)
+```bash
+git update-index --assume-unchanged rpcAuth.js
+```

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 
 If not already done, install Node.JS
 
-        For Debian / Ubuntu
+For Debian / Ubuntu
 
-   $ sudo apt-get install npm
-   $ sudo apt-get install nodejs-legacy
+$ sudo apt-get install npm
+$ sudo apt-get install nodejs-legacy
 
 Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
    ~/bitmark-audit $ npm install

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 An auditing suite for the Bitmark blockchain and mempool
 
 ### Setup
-The Bitmark configuration file must be set to allow JSON-RPC connections.  By defualt, Bitmark (or bitmarkd) will look for a file name `bitmark.conf` in the bitmark data directory, but both the data directory and the configuration file path may be changed using the -datadir and -conf command-line arguments.
+The Bitmark configuration file must be set to allow JSON-RPC connections.  By default, Bitmark (or bitmarkd) will look for a file name `bitmark.conf` in the bitmark data directory, but both the data directory and the configuration file path may be changed using the -datadir and -conf command-line arguments.
 
-| Operating System | Default bitmark datadir                    | Typical path to configuration file                                |
+| Operating System | Default bitmark datadir                    | Typical path to configuration file                               |
 |------------------|--------------------------------------------|------------------------------------------------------------------|
 | Windows          | %APPDATA%\Bitmark\                         | C:\Users\username\AppData\Roaming\Bitmark\bitmark.conf           |
 | Linux            | $HOME/.bitmark/                            | /home/username/.bitmark/bitmark.conf                             |
@@ -31,7 +31,7 @@ rpcpassword=You_Will_Get_Robbed_If_You_Use_This
 
 Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 
-Finally, `npm install` the required packages from `package.json`
+Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If not already done, install Node.JS
 
 For Debian / Ubuntu
 
-$ sudo apt-get install npm
-$ sudo apt-get install nodejs-legacy
+sudo apt-get install npm
+sudo apt-get install nodejs-legacy
 
 Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
    ~/bitmark-audit $ npm install

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 
 
 If not already done, install Node.JS
+
         For Debian / Ubuntu
+
    $ sudo apt-get install npm
    $ sudo apt-get install nodejs-legacy
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 If not already done, install Node.JS
 
 For Debian / Ubuntu
-
+```
 sudo apt-get install npm
 sudo apt-get install nodejs-legacy
-
+```
 Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
+```
    ~/bitmark-audit $ npm install
-
+```
 ### Usage
 
 Two tools are included in this repository: **monitor** and **audit**.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 An auditing suite for the Bitmark blockchain and mempool
 
 ### Setup
+
+##### Bitmark Configuration
 The Bitmark configuration file must be set to allow JSON-RPC connections.  By default, Bitmark (or bitmarkd) will look for a file name `bitmark.conf` in the bitmark data directory, but both the data directory and the configuration file path may be changed using the -datadir and -conf command-line arguments.
 
 | Operating System | Default bitmark datadir                    | Typical path to configuration file                               |
@@ -31,18 +33,20 @@ rpcpassword=You_Will_Get_Robbed_If_You_Use_This
 
 Edit `rpcAuth.js` to reflect the values set in `bitmark.conf`.
 
-
+##### Node.js
 If not already done, install Node.JS
 
 For Debian / Ubuntu
-```
+```bash
 sudo apt-get install npm
 sudo apt-get install nodejs-legacy
 ```
+
 Finally, run `npm install` in the ~/bitmark-audit directory to install the required packages from `package.json`
-```
+```bash
    ~/bitmark-audit $ npm install
 ```
+
 ### Usage
 
 Two tools are included in this repository: **monitor** and **audit**.


### PR DESCRIPTION
Expand README.md with Node.JS installation instructions for Debian / Ubuntu.

Put rpcAuth.js in the .gitignore file so passwords don't get uploaded to github.